### PR TITLE
Add planner buttons

### DIFF
--- a/waypoint_nav_plugin/CMakeLists.txt
+++ b/waypoint_nav_plugin/CMakeLists.txt
@@ -26,12 +26,13 @@ find_package(mav_manager_srv REQUIRED)
 find_package(rviz_ogre_vendor REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(rosbag2 REQUIRED)
+find_package(quadrotor_msgs REQUIRED)
 find_package(Qt5 REQUIRED COMPONENTS Core Gui Widgets Test Concurrent)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
 set(dependencies
-  rclcpp  
+  rclcpp
   Qt5
   rviz2
   rviz_common
@@ -43,6 +44,7 @@ set(dependencies
   pluginlib
   std_srvs
   mav_manager_srv
+  quadrotor_msgs
 )
 
 ## This setting causes Qt's "MOC" generation to happen automatically.
@@ -75,7 +77,7 @@ endforeach()
 ## "rviz_plugin_tutorials", or whatever your version of this project
 ## is called) and specify the list of source files we collected above
 ## in ``${SRC_FILES}``. We also add the needed dependencies.
-add_library(${PROJECT_NAME} SHARED ${SRC_FILES} 
+add_library(${PROJECT_NAME} SHARED ${SRC_FILES}
 ${${PROJECT_NAME}_UIS_H}
 ${${PROJECT_NAME}_MOCS}
 )

--- a/waypoint_nav_plugin/package.xml
+++ b/waypoint_nav_plugin/package.xml
@@ -18,6 +18,7 @@
   <depend>sensor_msgs</depend>
   <depend>rosbag2_cpp</depend>
   <depend>mav_manager_srv</depend>
+  <depend>quadrotor_msgs</depend>
 
   <build_depend>qtbase5-dev</build_depend>
 

--- a/waypoint_nav_plugin/src/waypoint_nav_frame.cpp
+++ b/waypoint_nav_plugin/src/waypoint_nav_frame.cpp
@@ -53,7 +53,7 @@
 namespace waypoint_nav_plugin
 {
 
-WaypointFrame::WaypointFrame(rviz_common::DisplayContext *context, std::map<int, Ogre::SceneNode* >* map_ptr, 
+WaypointFrame::WaypointFrame(rviz_common::DisplayContext *context, std::map<int, Ogre::SceneNode* >* map_ptr,
 interactive_markers::InteractiveMarkerServer* server, int* unique_ind, QWidget *parent, WaypointNavTool* wp_tool)
   : QWidget(parent)
   , context_(context)
@@ -68,10 +68,10 @@ interactive_markers::InteractiveMarkerServer* server, int* unique_ind, QWidget *
 {
   //scene_manager_ = context_->getSceneManager();
 
-  // set up the GUI 
+  // set up the GUI
   node = rclcpp::Node::make_shared("wp_node");
   ui_->setupUi(this);
-  pub_corridor_ = node->create_publisher<visualization_msgs::msg::MarkerArray>("corridors", 1); 
+  pub_corridor_ = node->create_publisher<visualization_msgs::msg::MarkerArray>("corridors", 1);
   wp_pub_ = node->create_publisher<nav_msgs::msg::Path>("waypoints", 1);
   path_clear_pub_ = node->create_publisher<std_msgs::msg::Bool>("/clear", 1);
   //connect the Qt signals and slots
@@ -90,10 +90,10 @@ interactive_markers::InteractiveMarkerServer* server, int* unique_ind, QWidget *
 
   connect(ui_->save_wp_button, SIGNAL(clicked()), this, SLOT(saveButtonClicked()));
   connect(ui_->load_wp_button, SIGNAL(clicked()), this, SLOT(loadButtonClicked()));
-  
+
   connect(ui_->perch, SIGNAL(clicked()), this, SLOT(perchClicked()));
 
-  //ROSRUN RQT Mav Manager Line topics 
+  //ROSRUN RQT Mav Manager Line topics
   connect(ui_->robot_name_line_edit, SIGNAL(editingFinished()), this, SLOT(robotChanged()));
   connect(ui_->node_name_line_edit, SIGNAL(editingFinished()), this, SLOT(serviceChanged()));
   //Buttons
@@ -110,9 +110,11 @@ interactive_markers::InteractiveMarkerServer* server, int* unique_ind, QWidget *
   connect(ui_->topic_overide, SIGNAL(stateChanged(int)), this, SLOT(topic_enable(int)));
   connect(ui_->motors_off_push_button, SIGNAL(clicked()), this, SLOT(motors_off_push_button()));
   connect(ui_->clear_path, SIGNAL(clicked()), this, SLOT(clear_path()));
-  
+  connect(ui_->exec_circle_button, SIGNAL(clicked()), this, SLOT(exec_circle_button()));
+  connect(ui_->exec_lissajous_button, SIGNAL(clicked()), this, SLOT(exec_lissajous_button()));
+
   connect(ui_->reset_map, SIGNAL(clicked()), this, SLOT(clear_map()));
-  
+
   node->declare_parameter("/"+ robot_name+"/"+"replan",false);
   node->declare_parameter("/"+ robot_name+"/"+"bern_enable",false);
 	//path_listen_ = nh_.subscribe("/quadrotor/trackers_manager/qp_tracker/qp_trajectory_pos", 10, &WaypointFrame::pos_listen, this);
@@ -168,7 +170,7 @@ void WaypointFrame::saveButtonClicked()
     QFileInfo info(filename);
     std::string filn = info.absolutePath().toStdString() + "/" + info.baseName().toStdString() + ".txt";
     wp_nav_tool_->savePoints(filn);
-  }   
+  }
 }
 
 void WaypointFrame::loadButtonClicked()
@@ -323,7 +325,7 @@ void WaypointFrame::replan_enable(int b)
 	 replan_enable_ = false;
   }
   //    wp_pub_ = node->create_publisher<nav_msgs::msg::Path>("/"+ robot_name +topic_name, 1);
-  node->set_parameters({rclcpp::Parameter("/"+ robot_name+"/"+"replan", replan_enable_)}); 
+  node->set_parameters({rclcpp::Parameter("/"+ robot_name+"/"+"replan", replan_enable_)});
   //nh_.setParam("/"+ robot_name+"/"+"replan",replan_enable_);
 }
 
@@ -519,7 +521,7 @@ void WaypointFrame::getPose(Eigen::Vector3f * position, Eigen::Vector4f * quat)
   }
 }
 
-//Quaternion is scalar last 
+//Quaternion is scalar last
 void WaypointFrame::setPose(Eigen::Vector3f  position, Eigen::Vector4f  quat)
 {
   {
@@ -572,7 +574,7 @@ void WaypointFrame::setPose(Eigen::Vector3f  position, Eigen::Vector4f  quat)
 /*
 void WaypointFrame::display(const nav_msgs::msg::Path &msg, int order){
 	double dt = 0.01;
-	//Record File 
+	//Record File
 	std::ofstream outFileX;
 	std::ofstream outFileY;
 	std::ofstream outFileZ;
@@ -582,8 +584,8 @@ void WaypointFrame::display(const nav_msgs::msg::Path &msg, int order){
 	outFileY.open("tempY"+der_app +".dat");
 	outFileZ.open("tempZ"+der_app +".dat");
 	for (int j=0; j< msg.poses.size(); j++){
-    geometry_msgs::PoseStamped ps = msg.poses[j];	
-    double time = ps.header.stamp.toSec();	
+    geometry_msgs::PoseStamped ps = msg.poses[j];
+    double time = ps.header.stamp.toSec();
     outFileX << time;
 		outFileX << " " << ps.pose.position.x << std::endl;
 		outFileY << time;
@@ -699,7 +701,7 @@ void WaypointFrame::hover_push_button(){
 
 void WaypointFrame::land_push_button(){
   boost::mutex::scoped_lock lock(frame_updates_mutex_);
-	std::string srvs_name = "/"+ robot_name+"/"+mav_node_name+"/land";	
+	std::string srvs_name = "/"+ robot_name+"/"+mav_node_name+"/land";
 	auto client = node->create_client<std_srvs::srv::Trigger>(srvs_name);
 	auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
 	auto result = client->async_send_request(request);
@@ -757,10 +759,87 @@ void WaypointFrame::goto_push_button(){
 		ROS_INFO("GoTo Success");
 	}
 	else
-	{	
+	{
 		ROS_ERROR("Failed GoTo ");
 	}		*/
 
+}
+
+bool WaypointFrame::extractFloats(const std::string& input, std::vector<float>& floats, int expectedCount) {
+    std::istringstream ss(input);
+    std::string token;
+
+    while (std::getline(ss, token, ',')) {
+        try {
+            float value = std::stof(token);
+            floats.push_back(value);
+        } catch (const std::invalid_argument& e) {
+            // Invalid float found in the string
+            return false;
+        }
+    }
+
+    // Check if the number of floats matches the expected count
+    if (floats.size() != expectedCount) {
+        return false;
+    }
+
+    return true;
+}
+
+
+void WaypointFrame::exec_circle_button(){
+  boost::mutex::scoped_lock lock(frame_updates_mutex_);
+  std::string srv_name = "/" + robot_name + "/trackers_manager/transition";
+
+	auto client = node->create_client<quadrotor_msgs::srv::Transition>(srv_name);
+	auto request = std::make_shared<quadrotor_msgs::srv::Transition::Request>();
+
+  std::string params = ui_->circle_params->text().toStdString();
+  std::vector<float> params_float;
+  if (!extractFloats(params, params_float, 4)) {
+    RCLCPP_ERROR(node->get_logger(), "incorrect circle planner arguments");
+    return;
+  }
+
+  request->tracker = "std_trackers/CirclePlanner";
+  request->planner_goal.circle_planner_goal.ax = params_float[0];
+  request->planner_goal.circle_planner_goal.ay = params_float[1];
+  request->planner_goal.circle_planner_goal.t = params_float[2];
+  request->planner_goal.circle_planner_goal.duration.sec = params_float[3];
+
+	auto result = client->async_send_request(request);
+  RCLCPP_INFO(node->get_logger(), "Sent Circle Request");
+}
+
+void WaypointFrame::exec_lissajous_button(){
+  boost::mutex::scoped_lock lock(frame_updates_mutex_);
+  std::string srv_name = "/" + robot_name + "/trackers_manager/transition";
+
+	auto client = node->create_client<quadrotor_msgs::srv::Transition>(srv_name);
+	auto request = std::make_shared<quadrotor_msgs::srv::Transition::Request>();
+
+  std::string params = ui_->lissajous_params->text().toStdString();
+  std::vector<float> params_float;
+  if (!extractFloats(params, params_float, 10)) {
+    RCLCPP_ERROR(node->get_logger(), "incorrect lissajous planner arguments");
+    return;
+  }
+
+  request->tracker = "std_trackers/LissajousPlanner";
+  request->planner_goal.lissajous_planner_goal.x_amp = params_float[0];
+  request->planner_goal.lissajous_planner_goal.y_amp = params_float[1];
+  request->planner_goal.lissajous_planner_goal.z_amp = params_float[2];
+  request->planner_goal.lissajous_planner_goal.x_num_periods = params_float[3];
+  request->planner_goal.lissajous_planner_goal.y_num_periods = params_float[4];
+  request->planner_goal.lissajous_planner_goal.z_num_periods = params_float[5];
+  request->planner_goal.lissajous_planner_goal.yaw_num_periods = params_float[6];
+  request->planner_goal.lissajous_planner_goal.period = params_float[7];
+  request->planner_goal.lissajous_planner_goal.num_cycles = params_float[8];
+  request->planner_goal.lissajous_planner_goal.ramp_time = params_float[9];
+
+	auto result = client->async_send_request(request);
+  RCLCPP_INFO(node->get_logger(), "Sent Lissajous Request");
 }
 
 void WaypointFrame::relativeChanged(int b){
@@ -774,7 +853,7 @@ void WaypointFrame::relativeChanged(int b){
 }
 
 
-void WaypointFrame::robotChanged(){ 
+void WaypointFrame::robotChanged(){
   boost::mutex::scoped_lock lock(frame_updates_mutex_);
   QString new_frame = ui_->robot_name_line_edit->text();
   robot_name =  new_frame.toStdString();

--- a/waypoint_nav_plugin/src/waypoint_nav_frame.hpp
+++ b/waypoint_nav_plugin/src/waypoint_nav_frame.hpp
@@ -67,6 +67,7 @@
 #include <rclcpp/serialization.hpp>
 #include <rosbag2_cpp/storage_options.hpp>
 #include <OgrePrerequisites.h>
+#include <quadrotor_msgs/srv/transition.hpp>
 
 typedef struct {
     int derivOrder, vertexNum;
@@ -131,7 +132,7 @@ public:
 
   bool getTopicOveride();
   bool getBernEnable();
-  
+
   double getDefaultHeight();
   double getTime();
   bool get2Ddisplay();
@@ -183,7 +184,11 @@ private Q_SLOTS:
   void hover_push_button();
   void clear_map();
   void clear_path();
+  void exec_circle_button();
+  void exec_lissajous_button();
    //Bernstein Check boxes
+
+  bool extractFloats(const std::string& input, std::vector<float>& floats, int expectedCount);
 
 
   //Inequality cahgned for each double box
@@ -204,7 +209,7 @@ private:
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr wp_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_corridor_;
   rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr path_clear_pub_;
-  
+
   //rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_ path_listen_;
   //rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_ vel_listen_;
   //rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_sub_ acc_listen_;
@@ -222,7 +227,7 @@ private:
   //default height the waypoint must be placed at
   double default_height_;
   double total_time_ = 0.0; //Jeff Addition Total Time of waypopints
-  bool display_2D = false; // Jeff additional boolean 
+  bool display_2D = false; // Jeff additional boolean
   bool relative_ = true;
   bool bern_enable_ = false;
   bool replan_enable_ = false;

--- a/waypoint_nav_plugin/ui/WaypointNavigation.ui
+++ b/waypoint_nav_plugin/ui/WaypointNavigation.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>575</width>
-    <height>831</height>
+    <width>783</width>
+    <height>1289</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,278 +17,20 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="7" column="1" colspan="3">
-    <widget class="QPushButton" name="goto_push_button">
+   <item row="29" column="0" colspan="2">
+    <widget class="QPushButton" name="save_wp_button">
      <property name="text">
-      <string>Go To</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="5">
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <item>
-      <widget class="QPushButton" name="motors_on_push_button">
-       <property name="text">
-        <string>Motors ON</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="hover">
-       <property name="text">
-        <string>Hover</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="motors_off_push_button">
-       <property name="styleSheet">
-        <string notr="true">color: rgb(255, 0, 0);</string>
-       </property>
-       <property name="text">
-        <string>Motors Off</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_time">
-     <property name="text">
-      <string>TotalTime: </string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="5">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="maximumSize">
-        <size>
-         <width>10</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>X</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDoubleSpinBox" name="x_doubleSpinBox_gt">
-       <property name="minimum">
-        <double>-99.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_2">
-       <property name="maximumSize">
-        <size>
-         <width>10</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Y:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDoubleSpinBox" name="y_doubleSpinBox_gt">
-       <property name="minimum">
-        <double>-99.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_3">
-       <property name="maximumSize">
-        <size>
-         <width>10</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Z:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDoubleSpinBox" name="z_doubleSpinBox_gt">
-       <property name="minimum">
-        <double>-99.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label_4">
-       <property name="maximumSize">
-        <size>
-         <width>35</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Yaw:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QDoubleSpinBox" name="yaw_doubleSpinBox_gt">
-       <property name="minimum">
-        <double>-99.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="10" column="2" colspan="3">
-    <widget class="QLineEdit" name="topic_line_edit">
-     <property name="text">
-      <string>/waypoints</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Node</string>
-     </property>
-    </widget>
-   </item>
-   <item row="17" column="4">
-    <widget class="QCheckBox" name="bern_enable">
-     <property name="text">
-      <string>Bernstein Traj</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <widget class="QCheckBox" name="topic_overide">
-     <property name="text">
-      <string>Topic Overide</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0">
-    <widget class="QLabel" name="wp_height_label">
-     <property name="text">
-      <string>Default Height</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Robot </string>
-     </property>
-    </widget>
-   </item>
-   <item row="24" column="0" colspan="5">
-    <layout class="QGridLayout" name="gridLayout_2">
-     <item row="0" column="1">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Expand X</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="3">
-      <widget class="QSlider" name="z_size">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QSlider" name="y_size">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>Expand Y</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="bern_ineq_en">
-       <property name="text">
-        <string>Corridor Plan</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QLabel" name="label_10">
-       <property name="text">
-        <string>Expand Z</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QSlider" name="x_size">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_topic">
-     <property name="text">
-      <string>Topic</string>
-     </property>
-    </widget>
-   </item>
-   <item row="19" column="2">
-    <widget class="QLabel" name="sel_wp_label">
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="4">
-    <widget class="QLineEdit" name="node_name_line_edit">
-     <property name="text">
-      <string>mav_services</string>
-     </property>
-    </widget>
-   </item>
-   <item row="26" column="2" colspan="3">
-    <widget class="QPushButton" name="publish_wp_button">
-     <property name="text">
-      <string>Publish Waypoints</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="4">
-    <widget class="QCheckBox" name="relative_checkbox">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="tabletTracking">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Relative</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
+      <string>Save Waypoints</string>
      </property>
     </widget>
    </item>
    <item row="13" column="4">
     <widget class="QDoubleSpinBox" name="TimeBox"/>
    </item>
-   <item row="27" column="2" colspan="3">
-    <widget class="QPushButton" name="load_wp_button">
+   <item row="16" column="0">
+    <widget class="QLabel" name="waypoint_count_label">
      <property name="text">
-      <string>Load Waypoints</string>
+      <string>Total Waypoints: </string>
      </property>
     </widget>
    </item>
@@ -299,40 +41,10 @@
      </property>
     </widget>
    </item>
-   <item row="11" column="2" colspan="3">
-    <widget class="QLineEdit" name="frame_line_edit">
+   <item row="29" column="2" colspan="3">
+    <widget class="QPushButton" name="load_wp_button">
      <property name="text">
-      <string>world</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="2">
-    <widget class="QLabel" name="label_7">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>20</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>QP Waypoint Nav.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="4">
-    <widget class="QDoubleSpinBox" name="wp_height_doubleSpinBox">
-     <property name="minimum">
-      <double>-5.000000000000000</double>
-     </property>
-     <property name="singleStep">
-      <double>0.100000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="4">
-    <widget class="QCheckBox" name="display2D">
-     <property name="text">
-      <string>Display 2D Plots</string>
+      <string>Load Waypoints</string>
      </property>
     </widget>
    </item>
@@ -427,70 +139,14 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0" colspan="5">
-    <layout class="QHBoxLayout" name="horizontalLayout_8">
-     <item>
-      <widget class="QPushButton" name="takeoff_push_button">
-       <property name="text">
-        <string>Take Off</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="go_home_button">
-       <property name="text">
-        <string>Go Home</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="land_push_button">
-       <property name="text">
-        <string>Land</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="19" column="4">
-    <widget class="QCheckBox" name="replan_enable">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Replan Enable</string>
+      <string>Robot </string>
      </property>
     </widget>
    </item>
-   <item row="16" column="0">
-    <widget class="QLabel" name="waypoint_count_label">
-     <property name="text">
-      <string>Total Waypoints: </string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QLineEdit" name="robot_name_line_edit">
-     <property name="inputMask">
-      <string/>
-     </property>
-     <property name="text">
-      <string>quadrotor</string>
-     </property>
-    </widget>
-   </item>
-   <item row="26" column="0" colspan="2">
-    <widget class="QPushButton" name="clear_all_button">
-     <property name="text">
-      <string>Clear All</string>
-     </property>
-    </widget>
-   </item>
-   <item row="27" column="0" colspan="2">
-    <widget class="QPushButton" name="save_wp_button">
-     <property name="text">
-      <string>Save Waypoints</string>
-     </property>
-    </widget>
-   </item>
-   <item row="25" column="0" colspan="5">
+   <item row="27" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QLabel" name="label_11">
@@ -538,6 +194,29 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QLineEdit" name="robot_name_line_edit">
+     <property name="inputMask">
+      <string/>
+     </property>
+     <property name="text">
+      <string>quadrotor</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="2">
+    <widget class="QLabel" name="label_7">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>20</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>QP Waypoint Nav.</string>
+     </property>
+    </widget>
+   </item>
    <item row="6" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
@@ -555,6 +234,487 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="15" column="4">
+    <widget class="QDoubleSpinBox" name="wp_height_doubleSpinBox">
+     <property name="minimum">
+      <double>-5.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.100000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Node</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="4">
+    <widget class="QCheckBox" name="replan_enable">
+     <property name="text">
+      <string>Replan Enable</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="4">
+    <widget class="QCheckBox" name="relative_checkbox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="tabletTracking">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Relative</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="5">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
+     <item>
+      <widget class="QPushButton" name="motors_on_push_button">
+       <property name="text">
+        <string>Motors ON</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="hover">
+       <property name="text">
+        <string>Hover</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="motors_off_push_button">
+       <property name="styleSheet">
+        <string notr="true">color: rgb(255, 0, 0);</string>
+       </property>
+       <property name="text">
+        <string>Motors Off</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="26" column="0" colspan="5">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="1" column="1">
+      <widget class="QSlider" name="x_size">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QSlider" name="z_size">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Expand X</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="bern_ineq_en">
+       <property name="text">
+        <string>Corridor Plan</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Expand Z</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QSlider" name="y_size">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_9">
+       <property name="text">
+        <string>Expand Y</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="16" column="4">
+    <widget class="QCheckBox" name="display2D">
+     <property name="text">
+      <string>Display 2D Plots</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_time">
+     <property name="text">
+      <string>TotalTime: </string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_topic">
+     <property name="text">
+      <string>Topic</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="3">
+    <widget class="QPushButton" name="goto_push_button">
+     <property name="text">
+      <string>Go To</string>
+     </property>
+    </widget>
+   </item>
+   <item row="19" column="2">
+    <widget class="QLabel" name="sel_wp_label">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="28" column="0" colspan="2">
+    <widget class="QPushButton" name="clear_all_button">
+     <property name="text">
+      <string>Clear All</string>
+     </property>
+    </widget>
+   </item>
+   <item row="17" column="4">
+    <widget class="QCheckBox" name="bern_enable">
+     <property name="text">
+      <string>Bernstein Traj</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="5">
+    <layout class="QHBoxLayout" name="horizontalLayout_8">
+     <item>
+      <widget class="QPushButton" name="takeoff_push_button">
+       <property name="text">
+        <string>Take Off</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="go_home_button">
+       <property name="text">
+        <string>Go Home</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="land_push_button">
+       <property name="text">
+        <string>Land</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="10" column="2" colspan="3">
+    <widget class="QLineEdit" name="topic_line_edit">
+     <property name="text">
+      <string>/waypoints</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="2" colspan="3">
+    <widget class="QLineEdit" name="frame_line_edit">
+     <property name="text">
+      <string>world</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QCheckBox" name="topic_overide">
+     <property name="text">
+      <string>Topic Overide</string>
+     </property>
+    </widget>
+   </item>
+   <item row="28" column="2" colspan="3">
+    <widget class="QPushButton" name="publish_wp_button">
+     <property name="text">
+      <string>Publish Waypoints</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="4">
+    <widget class="QLineEdit" name="node_name_line_edit">
+     <property name="text">
+      <string>mav_services</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0">
+    <widget class="QLabel" name="wp_height_label">
+     <property name="text">
+      <string>Default Height</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="5">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="maximumSize">
+        <size>
+         <width>10</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>X</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="x_doubleSpinBox_gt">
+       <property name="minimum">
+        <double>-99.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="maximumSize">
+        <size>
+         <width>10</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Y:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="y_doubleSpinBox_gt">
+       <property name="minimum">
+        <double>-99.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="maximumSize">
+        <size>
+         <width>10</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Z:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="z_doubleSpinBox_gt">
+       <property name="minimum">
+        <double>-99.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="maximumSize">
+        <size>
+         <width>35</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Yaw:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="yaw_doubleSpinBox_gt">
+       <property name="minimum">
+        <double>-99.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="23" column="0" rowspan="2" colspan="5">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetNoConstraint</enum>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_15">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>11</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Lissajous Planner</string>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>0</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_13">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Args: 
+x_amp, y_amp, z_amp, 
+ x_n, y_n, z_n, yaw_n, 
+ period, num_cycles, ramp_time </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lissajous_params"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="exec_lissajous_button">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>10</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="font">
+        <font>
+         <weight>50</weight>
+         <bold>false</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Execute</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>10</height>
+        </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>17</pointsize>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_16">
+       <property name="font">
+        <font>
+         <weight>75</weight>
+         <bold>true</bold>
+        </font>
+       </property>
+       <property name="text">
+        <string>Circle Planner</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_14">
+       <property name="text">
+        <string>Args: 
+x_radius, y_radius, time, duration</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="circle_params"/>
+     </item>
+     <item>
+      <widget class="QPushButton" name="exec_circle_button">
+       <property name="text">
+        <string>Execute</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="22" column="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Add buttons to directly execute circle and lissajous planners. Arguments are passed in through comma separated string in rviz gui. This fixes https://github.com/arplaboratory/arpl_quadrotor_control/issues/224 

here's a screenshot of what the gui should look like. the ui file has a alot of changes but I've only added buttons/text, not edited anything that was already present 

![Screenshot from 2024-01-21 15-37-33](https://github.com/arplaboratory/waypoint_navigation_plugin/assets/28722047/8f26d8ef-32d7-410c-93d8-737a6e801ce3)
