### PR TITLE
resolve crash when the mouse drag outside of 3D overlay

### DIFF
--- a/waypoint_navigation_plugin/src/waypoint_nav_tool_ros2.cpp
+++ b/waypoint_navigation_plugin/src/waypoint_nav_tool_ros2.cpp
@@ -190,10 +190,9 @@ int WaypointNavTool::processMouseEvent(rviz_common::ViewportMouseEvent& event)
   auto projection_finder = std::make_shared<rviz_rendering::ViewportProjectionFinder>();
   auto projection = projection_finder->getViewportPointProjectionOnXYPlane(
     event.panel->getRenderWindow(), event.x, event.y);
-  Ogre::Vector3 intersection = projection.second;
 
     if (projection.first) {
-
+      Ogre::Vector3 intersection = projection.second;
       moving_flag_node_->setVisible(true);
       moving_flag_node_->setPosition(intersection);
       frame_->setWpLabel();


### PR DESCRIPTION
The crash occurs in processMouseEvent at line 193 where intersection is assigned from projection.second without checking if the projection was successful. When the mouse is dragged outside the 3D frame, projection.first is false, but the code still uses projection.second which may be uninitialized.